### PR TITLE
feat: rename to @f5xc-salesdemos/starlight-mega-menu and add i18n support

### DIFF
--- a/components/MegaMenu.tsx
+++ b/components/MegaMenu.tsx
@@ -1,5 +1,19 @@
+import * as React from 'react';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
-import type { MegaMenuConfig, MegaMenuPanel, MegaMenuCategory, MegaMenuLink as MegaMenuLinkType, MegaMenuFooter } from '../types';
+import type { MegaMenuConfig, MegaMenuPanel, MegaMenuCategory, MegaMenuLink as MegaMenuLinkType, MegaMenuFooter, I18nString } from '../types';
+
+function useLocale(): string {
+  const [locale, setLocale] = React.useState('en');
+  React.useEffect(() => {
+    setLocale(document.documentElement.lang || 'en');
+  }, []);
+  return locale;
+}
+
+function t(text: string, translations?: I18nString, locale?: string): string {
+  if (!translations || !locale) return text;
+  return translations[locale] || text;
+}
 
 function ChevronDown({ className }: { className?: string }) {
   return (
@@ -23,7 +37,7 @@ function ChevronDown({ className }: { className?: string }) {
   );
 }
 
-function PanelContent({ panel }: { panel: MegaMenuPanel }) {
+function PanelContent({ panel, locale }: { panel: MegaMenuPanel; locale: string }) {
   const layout = panel.layout ?? 'list';
   const columns = panel.columns ?? 2;
 
@@ -34,21 +48,21 @@ function PanelContent({ panel }: { panel: MegaMenuPanel }) {
       style={layout === 'grid' ? { '--smm-columns': columns } as React.CSSProperties : undefined}
     >
       {panel.categories?.map((category) => (
-        <CategorySection key={category.title} category={category} />
+        <CategorySection key={category.title} category={category} locale={locale} />
       ))}
-      {panel.footer && <PanelFooter footer={panel.footer} />}
+      {panel.footer && <PanelFooter footer={panel.footer} locale={locale} />}
     </div>
   );
 }
 
-function CategorySection({ category }: { category: MegaMenuCategory }) {
+function CategorySection({ category, locale }: { category: MegaMenuCategory; locale: string }) {
   return (
     <div className="smm-category">
-      <h3 className="smm-category-title">{category.title}</h3>
+      <h3 className="smm-category-title">{t(category.title, category.translations, locale)}</h3>
       <ul className="smm-category-list">
         {category.items.map((item) => (
           <li key={item.href}>
-            <LinkItem item={item} />
+            <LinkItem item={item} locale={locale} />
           </li>
         ))}
       </ul>
@@ -56,29 +70,29 @@ function CategorySection({ category }: { category: MegaMenuCategory }) {
   );
 }
 
-function LinkItem({ item }: { item: MegaMenuLinkType }) {
+function LinkItem({ item, locale }: { item: MegaMenuLinkType; locale: string }) {
   return (
     <NavigationMenu.Link className="smm-menu-link" href={item.href}>
       {item.icon && (
         <span className="smm-link-icon" dangerouslySetInnerHTML={{ __html: item.icon }} />
       )}
       <span className="smm-link-text">
-        <span className="smm-link-label">{item.label}</span>
+        <span className="smm-link-label">{t(item.label, item.translations, locale)}</span>
         {item.description && (
-          <span className="smm-link-description">{item.description}</span>
+          <span className="smm-link-description">{t(item.description, item.descriptionTranslations, locale)}</span>
         )}
       </span>
     </NavigationMenu.Link>
   );
 }
 
-function PanelFooter({ footer }: { footer: MegaMenuFooter }) {
+function PanelFooter({ footer, locale }: { footer: MegaMenuFooter; locale: string }) {
   return (
     <div className="smm-panel-footer">
       <NavigationMenu.Link className="smm-footer-link" href={footer.href}>
-        <span className="smm-footer-label">{footer.label}</span>
+        <span className="smm-footer-label">{t(footer.label, footer.translations, locale)}</span>
         {footer.description && (
-          <span className="smm-footer-description">{footer.description}</span>
+          <span className="smm-footer-description">{t(footer.description, footer.descriptionTranslations, locale)}</span>
         )}
         <svg
           className="smm-footer-arrow"
@@ -103,6 +117,8 @@ function PanelFooter({ footer }: { footer: MegaMenuFooter }) {
 }
 
 export default function MegaMenu({ config }: { config: MegaMenuConfig }) {
+  const locale = useLocale();
+
   return (
     <NavigationMenu.Root className="smm-root" delayDuration={200} skipDelayDuration={300}>
       <NavigationMenu.List className="smm-list">
@@ -110,17 +126,17 @@ export default function MegaMenu({ config }: { config: MegaMenuConfig }) {
           item.content ? (
             <NavigationMenu.Item key={item.label} value={item.label}>
               <NavigationMenu.Trigger className="smm-trigger">
-                {item.label}
+                {t(item.label, item.translations, locale)}
                 <ChevronDown className="smm-chevron" />
               </NavigationMenu.Trigger>
               <NavigationMenu.Content className="smm-content">
-                <PanelContent panel={item.content} />
+                <PanelContent panel={item.content} locale={locale} />
               </NavigationMenu.Content>
             </NavigationMenu.Item>
           ) : (
             <NavigationMenu.Item key={item.label}>
               <NavigationMenu.Link className="smm-link" href={item.href}>
-                {item.label}
+                {t(item.label, item.translations, locale)}
               </NavigationMenu.Link>
             </NavigationMenu.Item>
           )

--- a/components/MegaMenuMobile.tsx
+++ b/components/MegaMenuMobile.tsx
@@ -1,5 +1,18 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { MegaMenuConfig } from '../types';
+import type { MegaMenuConfig, I18nString } from '../types';
+
+function t(text: string, translations?: I18nString, locale?: string): string {
+  if (!translations || !locale) return text;
+  return translations[locale] || text;
+}
+
+function useLocale(): string {
+  const [locale, setLocale] = useState('en');
+  useEffect(() => {
+    setLocale(document.documentElement.lang || 'en');
+  }, []);
+  return locale;
+}
 
 function HamburgerIcon() {
   return (
@@ -47,13 +60,14 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
   const [isOpen, setIsOpen] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const locale = useLocale();
+  const ml = config.mobileLabels;
 
   const close = useCallback(() => {
     setIsOpen(false);
     triggerRef.current?.focus();
   }, []);
 
-  // Close on Escape key
   useEffect(() => {
     if (!isOpen) return;
     function handleKeyDown(e: KeyboardEvent) {
@@ -65,7 +79,6 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, close]);
 
-  // Lock body scroll when open
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = 'hidden';
@@ -77,7 +90,6 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
     };
   }, [isOpen]);
 
-  // Focus trap: focus the dialog when it opens
   useEffect(() => {
     if (isOpen && dialogRef.current) {
       dialogRef.current.focus();
@@ -91,31 +103,29 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
         className="smm-mobile-button"
         onClick={() => setIsOpen(true)}
         aria-expanded={isOpen}
-        aria-label="Open navigation menu"
+        aria-label={t(ml?.open || 'Open navigation menu', ml?.openTranslations, locale)}
       >
         <HamburgerIcon />
       </button>
 
       {isOpen && (
         <>
-          {/* Backdrop */}
           <div className="smm-mobile-backdrop" onClick={close} />
 
-          {/* Overlay panel */}
           <div
             ref={dialogRef}
             className="smm-mobile-overlay"
             role="dialog"
             aria-modal="true"
-            aria-label="Navigation menu"
+            aria-label={t(ml?.menu || 'Menu', ml?.menuTranslations, locale)}
             tabIndex={-1}
           >
             <div className="smm-mobile-header">
-              <span className="smm-mobile-title">Menu</span>
+              <span className="smm-mobile-title">{t(ml?.menu || 'Menu', ml?.menuTranslations, locale)}</span>
               <button
                 className="smm-mobile-close"
                 onClick={close}
-                aria-label="Close navigation menu"
+                aria-label={t(ml?.close || 'Close navigation menu', ml?.closeTranslations, locale)}
               >
                 <CloseIcon />
               </button>
@@ -126,7 +136,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                 item.content ? (
                   <details key={item.label} className="smm-mobile-section">
                     <summary className="smm-mobile-summary">
-                      {item.label}
+                      {t(item.label, item.translations, locale)}
                       <svg
                         className="smm-mobile-chevron"
                         xmlns="http://www.w3.org/2000/svg"
@@ -148,7 +158,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                     <div className="smm-mobile-panel">
                       {item.content.categories?.map((category) => (
                         <div key={category.title} className="smm-mobile-category">
-                          <h3 className="smm-mobile-category-title">{category.title}</h3>
+                          <h3 className="smm-mobile-category-title">{t(category.title, category.translations, locale)}</h3>
                           <ul className="smm-mobile-category-list">
                             {category.items.map((link) => (
                               <li key={link.href}>
@@ -164,9 +174,9 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                                     />
                                   )}
                                   <span className="smm-mobile-link-text">
-                                    <span className="smm-mobile-link-label">{link.label}</span>
+                                    <span className="smm-mobile-link-label">{t(link.label, link.translations, locale)}</span>
                                     {link.description && (
-                                      <span className="smm-mobile-link-desc">{link.description}</span>
+                                      <span className="smm-mobile-link-desc">{t(link.description, link.descriptionTranslations, locale)}</span>
                                     )}
                                   </span>
                                 </a>
@@ -181,7 +191,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                           href={item.content.footer.href}
                           onClick={close}
                         >
-                          {item.content.footer.label}
+                          {t(item.content.footer.label, item.content.footer.translations, locale)}
                         </a>
                       )}
                     </div>
@@ -193,7 +203,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                     href={item.href}
                     onClick={close}
                   >
-                    {item.label}
+                    {t(item.label, item.translations, locale)}
                   </a>
                 )
               )}

--- a/index.ts
+++ b/index.ts
@@ -11,6 +11,7 @@ export type {
   MegaMenuCategory,
   MegaMenuLink,
   MegaMenuFooter,
+  I18nString,
 } from './types';
 
 export default function starlightMegaMenu(config: MegaMenuConfig): StarlightPlugin {
@@ -47,11 +48,11 @@ export default function starlightMegaMenu(config: MegaMenuConfig): StarlightPlug
         updateConfig({
           customCss: [
             ...(starlightConfig.customCss ?? []),
-            'starlight-mega-menu/components/mega-menu.css',
+            '@f5xc-salesdemos/starlight-mega-menu/components/mega-menu.css',
           ],
           components: {
             ...starlightConfig.components,
-            Header: 'starlight-mega-menu/components/Header.astro',
+            Header: '@f5xc-salesdemos/starlight-mega-menu/components/Header.astro',
           },
         });
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "starlight-mega-menu",
+  "name": "@f5xc-salesdemos/starlight-mega-menu",
   "version": "0.0.0-development",
-  "description": "A mega-menu navigation plugin for Astro Starlight",
+  "description": "A mega-menu navigation plugin for Astro Starlight with i18n support",
   "type": "module",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": "./index.ts",
     "./components/Header.astro": "./components/Header.astro",

--- a/types.ts
+++ b/types.ts
@@ -1,50 +1,50 @@
+export type I18nString = Record<string, string>;
+
 export interface MegaMenuConfig {
   items: MegaMenuItem[];
+  mobileLabels?: {
+    open?: string;
+    openTranslations?: I18nString;
+    close?: string;
+    closeTranslations?: I18nString;
+    menu?: string;
+    menuTranslations?: I18nString;
+  };
 }
 
 export interface MegaMenuItem {
-  /** Display label for the menu item */
   label: string;
-  /** Simple link (no dropdown). Mutually exclusive with `content`. */
+  translations?: I18nString;
   href?: string;
-  /** Dropdown panel content. Mutually exclusive with `href`. */
   content?: MegaMenuPanel;
 }
 
 export interface MegaMenuPanel {
-  /** Panel layout style. Default: 'list' */
   layout?: 'grid' | 'list';
-  /** Number of grid columns (only applies when layout is 'grid'). Default: 2 */
   columns?: number;
-  /** Grouped link categories within the panel */
   categories?: MegaMenuCategory[];
-  /** Optional footer link at the bottom of the panel */
   footer?: MegaMenuFooter;
 }
 
 export interface MegaMenuCategory {
-  /** Category heading */
   title: string;
-  /** Links within this category */
+  translations?: I18nString;
   items: MegaMenuLink[];
 }
 
 export interface MegaMenuLink {
-  /** Display label */
   label: string;
-  /** Optional description text below the label */
+  translations?: I18nString;
   description?: string;
-  /** Link URL */
+  descriptionTranslations?: I18nString;
   href: string;
-  /** Optional inline SVG string for an icon */
   icon?: string;
 }
 
 export interface MegaMenuFooter {
-  /** Footer link label */
   label: string;
-  /** Footer link URL */
+  translations?: I18nString;
   href: string;
-  /** Optional description */
   description?: string;
+  descriptionTranslations?: I18nString;
 }


### PR DESCRIPTION
## Summary

- Rename package to `@f5xc-salesdemos/starlight-mega-menu`
- Add optional `translations` field to `MegaMenuItem`, `MegaMenuCategory`, `MegaMenuLink`, `MegaMenuFooter`
- React components read `document.documentElement.lang` at runtime for locale-aware rendering
- Add `mobileLabels` config for translating mobile menu aria-labels
- Fully backward compatible — all translation fields are optional

## BREAKING CHANGE

Package renamed. Update imports from `starlight-mega-menu` to `@f5xc-salesdemos/starlight-mega-menu`.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)