### PR TITLE
feat: add cross-repository locale injection for ecosystem links

### DIFF
--- a/components/MegaMenu.tsx
+++ b/components/MegaMenu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import type { MegaMenuConfig, MegaMenuPanel, MegaMenuCategory, MegaMenuLink as MegaMenuLinkType, MegaMenuFooter, I18nString } from '../types';
+import { langToSlug, localizeEcosystemHref } from '../libs/localize-ecosystem-href.ts';
 
 function useLocale(): string {
   const [locale, setLocale] = React.useState('en');
@@ -72,7 +73,7 @@ function CategorySection({ category, locale }: { category: MegaMenuCategory; loc
 
 function LinkItem({ item, locale }: { item: MegaMenuLinkType; locale: string }) {
   return (
-    <NavigationMenu.Link className="smm-menu-link" href={item.href}>
+    <NavigationMenu.Link className="smm-menu-link" href={localizeEcosystemHref(item.href, langToSlug(locale))}>
       {item.icon && (
         <span className="smm-link-icon" dangerouslySetInnerHTML={{ __html: item.icon }} />
       )}
@@ -89,7 +90,7 @@ function LinkItem({ item, locale }: { item: MegaMenuLinkType; locale: string }) 
 function PanelFooter({ footer, locale }: { footer: MegaMenuFooter; locale: string }) {
   return (
     <div className="smm-panel-footer">
-      <NavigationMenu.Link className="smm-footer-link" href={footer.href}>
+      <NavigationMenu.Link className="smm-footer-link" href={localizeEcosystemHref(footer.href, langToSlug(locale))}>
         <span className="smm-footer-label">{t(footer.label, footer.translations, locale)}</span>
         {footer.description && (
           <span className="smm-footer-description">{t(footer.description, footer.descriptionTranslations, locale)}</span>
@@ -135,7 +136,7 @@ export default function MegaMenu({ config }: { config: MegaMenuConfig }) {
             </NavigationMenu.Item>
           ) : (
             <NavigationMenu.Item key={item.label}>
-              <NavigationMenu.Link className="smm-link" href={item.href}>
+              <NavigationMenu.Link className="smm-link" href={localizeEcosystemHref(item.href || '', langToSlug(locale))}>
                 {t(item.label, item.translations, locale)}
               </NavigationMenu.Link>
             </NavigationMenu.Item>

--- a/components/MegaMenuMobile.tsx
+++ b/components/MegaMenuMobile.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { MegaMenuConfig, I18nString } from '../types';
+import { langToSlug, localizeEcosystemHref } from '../libs/localize-ecosystem-href.ts';
 
 function t(text: string, translations?: I18nString, locale?: string): string {
   if (!translations || !locale) return text;
@@ -164,7 +165,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                               <li key={link.href}>
                                 <a
                                   className="smm-mobile-link"
-                                  href={link.href}
+                                  href={localizeEcosystemHref(link.href, langToSlug(locale))}
                                   onClick={close}
                                 >
                                   {link.icon && (
@@ -188,7 +189,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                       {item.content.footer && (
                         <a
                           className="smm-mobile-footer-link"
-                          href={item.content.footer.href}
+                          href={localizeEcosystemHref(item.content.footer.href, langToSlug(locale))}
                           onClick={close}
                         >
                           {t(item.content.footer.label, item.content.footer.translations, locale)}
@@ -200,7 +201,7 @@ export default function MegaMenuMobile({ config }: { config: MegaMenuConfig }) {
                   <a
                     key={item.label}
                     className="smm-mobile-top-link"
-                    href={item.href}
+                    href={localizeEcosystemHref(item.href || '', langToSlug(locale))}
                     onClick={close}
                   >
                     {t(item.label, item.translations, locale)}

--- a/libs/localize-ecosystem-href.ts
+++ b/libs/localize-ecosystem-href.ts
@@ -1,0 +1,45 @@
+const ECOSYSTEM_HOST = 'f5xc-salesdemos.github.io';
+
+const VALID_LOCALE_SLUGS = new Set([
+  'en', 'fr', 'es', 'de', 'pt-br', 'ja', 'ko',
+  'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th',
+]);
+
+const LANG_TO_SLUG: Record<string, string> = {
+  'pt-BR': 'pt-br',
+  'zh-CN': 'zh-cn',
+  'zh-TW': 'zh-tw',
+};
+
+export function langToSlug(lang: string): string {
+  return LANG_TO_SLUG[lang] || lang.toLowerCase();
+}
+
+export function localizeEcosystemHref(
+  href: string,
+  localeSlug: string,
+  ecosystemHost: string = ECOSYSTEM_HOST,
+): string {
+  if (!localeSlug || !VALID_LOCALE_SLUGS.has(localeSlug)) return href;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  if (url.hostname !== ecosystemHost) return href;
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return href;
+
+  if (segments.length >= 2 && VALID_LOCALE_SLUGS.has(segments[1])) {
+    return href;
+  }
+
+  segments.splice(1, 0, localeSlug);
+  url.pathname = '/' + segments.join('/') + '/';
+
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

- Add `localizeEcosystemHref()` utility that injects the current locale slug into `f5xc-salesdemos.github.io` links
- Wrap all MegaMenu and MegaMenuMobile link hrefs with locale injection
- External links (console.ves.volterra.io, github.com, etc.) are left unchanged
- Maps BCP-47 lang attributes (pt-BR, zh-CN) to URL slugs (pt-br, zh-cn)

Closes #3

## Test plan

- [ ] Build docs-theme locally and verify MegaMenu links include locale in non-English pages
- [ ] Verify external links remain unchanged
- [ ] Test mobile menu locale injection

🤖 Generated with [Claude Code](https://claude.com/claude-code)