### PR TITLE
fix: use RELEASE_TOKEN secret in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,6 @@ jobs:
             attempt=$((attempt + 1))
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Change `GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}` to `GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}`
- Matches the docs-theme release workflow pattern that works with org-level secrets
- Unblocks npm publishing of starlight-mega-menu packages

Closes #6

## Test plan

- [ ] Merge this PR
- [ ] Verify the release workflow triggers and runs semantic-release successfully
- [ ] Confirm new npm version is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)