### PR TITLE
refactor: replace inline locale definitions with i18n-core imports

### DIFF
--- a/libs/localize-ecosystem-href.ts
+++ b/libs/localize-ecosystem-href.ts
@@ -1,26 +1,15 @@
+import { VALID_SLUGS, bcp47ToSlug } from '@f5xc-salesdemos/i18n-core';
+
 const ECOSYSTEM_HOST = 'f5xc-salesdemos.github.io';
 
-const VALID_LOCALE_SLUGS = new Set([
-  'en', 'fr', 'es', 'de', 'pt-br', 'ja', 'ko',
-  'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th',
-]);
-
-const LANG_TO_SLUG: Record<string, string> = {
-  'pt-BR': 'pt-br',
-  'zh-CN': 'zh-cn',
-  'zh-TW': 'zh-tw',
-};
-
-export function langToSlug(lang: string): string {
-  return LANG_TO_SLUG[lang] || lang.toLowerCase();
-}
+export const langToSlug = bcp47ToSlug;
 
 export function localizeEcosystemHref(
   href: string,
   localeSlug: string,
   ecosystemHost: string = ECOSYSTEM_HOST,
 ): string {
-  if (!localeSlug || !VALID_LOCALE_SLUGS.has(localeSlug)) return href;
+  if (!localeSlug || !VALID_SLUGS.has(localeSlug)) return href;
 
   let url: URL;
   try {
@@ -34,7 +23,7 @@ export function localizeEcosystemHref(
   const segments = url.pathname.split('/').filter(Boolean);
   if (segments.length === 0) return href;
 
-  if (segments.length >= 2 && VALID_LOCALE_SLUGS.has(segments[1])) {
+  if (segments.length >= 2 && VALID_SLUGS.has(segments[1])) {
     return href;
   }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
+    "@f5xc-salesdemos/i18n-core": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `VALID_LOCALE_SLUGS` and `LANG_TO_SLUG` with `VALID_SLUGS` and `bcp47ToSlug` from `@f5xc-salesdemos/i18n-core`
- Add `@f5xc-salesdemos/i18n-core` as dependency

Closes #8

## Test plan
- [ ] Verify mega-menu locale-aware ecosystem href localization works
- [ ] Verify langToSlug export still works for consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)