### PR TITLE
chore: update org name from f5xc-salesdemos to f5-sales-demo

### DIFF
--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -15,4 +15,4 @@ permissions:
 jobs:
   audit:
     # Read-only freshness audit — no secrets required.
-    uses: f5xc-salesdemos/docs-control/.github/workflows/translation-audit.yml@main
+    uses: f5-sales-demo/docs-control/.github/workflows/translation-audit.yml@main

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@f5xc-salesdemos/starlight-mega-menu",
+  "name": "@f5-sales-demo/starlight-mega-menu",
   "version": "0.0.0-development",
   "description": "A mega-menu navigation plugin for Astro Starlight with i18n support",
   "type": "module",
@@ -31,7 +31,7 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
-    "@f5xc-salesdemos/i18n-core": "^1.0.0",
+    "@f5-sales-demo/i18n-core": "^1.0.0",
     "@radix-ui/react-navigation-menu": "^1.2.0"
   }
 }


### PR DESCRIPTION
Closes #16

Updated 2 file(s) for org rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)