### PR TITLE
fix: correct stale pre-rename homepage URL

### DIFF
--- a/.github/config/repo-settings.json
+++ b/.github/config/repo-settings.json
@@ -1,7 +1,7 @@
 {
   "repository": {
     "description": "A mega-menu navigation plugin for Astro Starlight",
-    "homepage": "https://robinmordasiewicz.github.io/starlight-mega-menu/"
+    "homepage": "https://f5-sales-demo.github.io/starlight-mega-menu/"
   },
   "topics": ["starlight", "astro", "mega-menu", "navigation", "plugin"]
 }


### PR DESCRIPTION
Points `homepage` in repo-settings.json at the live Pages URL (`f5-sales-demo.github.io`) instead of the pre-rename `robinmordasiewicz.github.io`.

First real Claude-review UAT on this newly-gated repo (non-bypass `fix/` branch → the actual reviewer runs).

Closes #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)