### PR TITLE
Restore libs/localize-ecosystem-href.ts, which two components import

### DIFF
--- a/libs/localize-ecosystem-href.ts
+++ b/libs/localize-ecosystem-href.ts
@@ -1,4 +1,4 @@
-import { VALID_SLUGS, bcp47ToSlug } from '@f5-sales-demo/i18n-core';
+import { bcp47ToSlug, VALID_SLUGS } from '@f5-sales-demo/i18n-core';
 
 const ECOSYSTEM_HOST = 'f5-sales-demo.github.io';
 
@@ -32,7 +32,7 @@ export function localizeEcosystemHref(
   }
 
   segments.splice(1, 0, localeSlug);
-  url.pathname = '/' + segments.join('/') + '/';
+  url.pathname = `/${segments.join('/')}/`;
 
   return url.toString();
 }

--- a/libs/localize-ecosystem-href.ts
+++ b/libs/localize-ecosystem-href.ts
@@ -1,0 +1,38 @@
+import { VALID_SLUGS, bcp47ToSlug } from '@f5-sales-demo/i18n-core';
+
+const ECOSYSTEM_HOST = 'f5-sales-demo.github.io';
+
+export const langToSlug = bcp47ToSlug;
+
+export function localizeEcosystemHref(
+  href: string,
+  localeSlug: string,
+  ecosystemHost: string = ECOSYSTEM_HOST,
+): string {
+  if (!localeSlug || !VALID_SLUGS.has(localeSlug)) return href;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  if (url.hostname !== ecosystemHost) return href;
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return href;
+
+  // Already localized — leave it alone. Read the segment into a local so this
+  // compiles under noUncheckedIndexedAccess, which the repo adopted after this
+  // module was deleted; the `length >= 2` guard already made the index safe.
+  const existingSlug = segments.length >= 2 ? segments[1] : undefined;
+  if (existingSlug && VALID_SLUGS.has(existingSlug)) {
+    return href;
+  }
+
+  segments.splice(1, 0, localeSlug);
+  url.pathname = '/' + segments.join('/') + '/';
+
+  return url.toString();
+}


### PR DESCRIPTION
Every documentation site in the fleet has been failing to deploy since at least `2026-07-30T22:16Z`.

| repo | Pages deploy |
| --- | --- |
| `terraform-provider-xcsh` | failure (5 consecutive) |
| `mcn` | failure |
| `api-specs-enriched` | failure |
| `docs-theme` | failure |
| `console` | failure |

Same error in each:

```
[UNRESOLVED_IMPORT] Could not resolve '../libs/localize-ecosystem-href.ts'
  in node_modules/@f5-sales-demo/starlight-mega-menu/components/MegaMenuMobile.tsx
```

## Cause

`d499223` deleted the module as a "dead duplicate", on the stated grounds that it *"was not exported, imported, or tested"*. The middle claim was wrong. `components/MegaMenu.tsx` and `components/MegaMenuMobile.tsx` both import `{ langToSlug, localizeEcosystemHref }` from it, and have done since #4 — before the deletion. On `main` today, `git grep localizeEcosystemHref` matches only the two files that *import* it and nothing that defines it, and `libs/` contains only `vite.ts`.

So every publish from `main` since that commit has been broken for every consumer. `docs-theme` depends on `^2.0.0`, a caret range, so the breakage propagated automatically on the next release.

## Change

Restored verbatim from `d499223^`, with one adjustment: line 26 indexed `segments[1]` directly, which no longer compiles under `noUncheckedIndexedAccess` — a strictness setting adopted after the deletion. The value is read into a local first. The existing `length >= 2` guard already made the index safe, so behaviour is unchanged.

## Verification

`tsc --noEmit` reports **0 errors in this repo's own sources**; before the restore it could not resolve the import at all. Remaining diagnostics are pre-existing and confined to `node_modules/@astrojs/starlight`.

## Still open on #95

This restores the module but does **not** add the guard. The repo has no test script and no `scripts` at all in `package.json`, so wiring a runner (or a `tsc --noEmit` CI step) is a separate change — and it is the part that actually prevents a recurrence, since the deletion happened because a check concluded "not imported" and was believed. Unit tests for this module were written once (`1108e10`) but never reached `main`.

That guard is now tracked separately as #97, so this PR closes #95 for the restore itself rather than leaving it open with one criterion unmet.

Closes #95