### PR TITLE
fix: publish the restored localize-ecosystem-href module

### DIFF
--- a/libs/localize-ecosystem-href.ts
+++ b/libs/localize-ecosystem-href.ts
@@ -1,3 +1,12 @@
+// Imported by components/MegaMenu.tsx and components/MegaMenuMobile.tsx.
+//
+// Stated here because this module was once deleted as a "dead duplicate" on the
+// grounds that it "was not exported, imported, or tested" (d499223). It was imported,
+// by both of those components, and removing it broke the documentation build of every
+// consumer of this package until it was restored in #96. There is still no CI gate that
+// would catch an unresolvable import (#97), so until there is, this comment is the
+// guard.
+
 import { bcp47ToSlug, VALID_SLUGS } from '@f5-sales-demo/i18n-core';
 
 const ECOSYSTEM_HOST = 'f5-sales-demo.github.io';


### PR DESCRIPTION
## The fix is on main and every consumer is still broken

#96 restored `libs/localize-ecosystem-href.ts` and merged. **No release was published.**

```
[semantic-release] [@semantic-release/commit-analyzer]
  › ℹ  Analysis of 1 commits complete: no release
[semantic-release] › ℹ  There are no relevant changes, so no new version is released.
```

This repo squashes with the PR title (`squash_merge_commit_title: COMMIT_OR_PR_TITLE`), and #96's title carried no conventional-commit prefix. So semantic-release skipped it, the latest published version is still the one without the module, and the Pages deploy of `mcn`, `terraform-provider-xcsh`, `api-specs-enriched`, `docs-theme` and `docs-control` still fails on the unresolvable import.

The `Release` workflow reported **success** throughout. It did exactly what it was told; nothing was wrong with it. But "Release succeeded" and "a release exists" turn out to be different statements, and only the second one matters to consumers.

## This change

A conventional prefix, so the release actually goes out.

It also adds a header comment naming the two importers. That is the precise fact whose absence caused the original deletion — `d499223` removed the module on the stated grounds that it *"was not exported, imported, or tested"*, and it was imported, by `components/MegaMenu.tsx` and `components/MegaMenuMobile.tsx`.

## What this does not do

It does not add the CI gate. `tsconfig.json` is a bare `extends: astro/tsconfigs/strictest` with no `jsx` setting and no includes, so `tsc --noEmit` currently reports 193 errors across this repo's own sources — a clean typecheck gate means fixing that configuration first. Tracked on #97, and the comment above says so in the file itself so the gap is visible where it matters.

Closes #99

Refs #95, #97