### PR TITLE
chore(governance): bootstrap exact managed caller

### DIFF
--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -25,7 +25,9 @@ concurrency:
 
 jobs:
   resolve-source:
+    name: Resolve protected governance source
     runs-on: ubuntu-latest
+    environment: repository-settings
     outputs:
       source_sha: ${{ steps.resolve.outputs.source_sha }}
       ready: ${{ steps.resolve.outputs.ready }}
@@ -251,7 +253,7 @@ jobs:
   enforce-settings:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@110128c21a3ebc90dcf661294d61553715bafd96
+    uses: f5-sales-demo/docs-control/.github/workflows/enforce-repo-settings.yml@1f390d9f64ccc510a0b4d0285ba1daafe9172bfd
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
     secrets:
@@ -260,7 +262,7 @@ jobs:
   sync-files:
     needs: resolve-source
     if: needs.resolve-source.outputs.ready == 'true'
-    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@110128c21a3ebc90dcf661294d61553715bafd96
+    uses: f5-sales-demo/docs-control/.github/workflows/sync-managed-files.yml@1f390d9f64ccc510a0b4d0285ba1daafe9172bfd
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
       downstream_sha: ${{ github.sha }}


### PR DESCRIPTION
Installs one exact managed caller before fleet enforcement resumes. The sync/ branch uses the governed automation exemption from linked-issue enforcement.