### PR TITLE
docs: verify linked-issue check

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -30,3 +30,4 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     Fully typed configuration with IntelliSense support for a great developer experience.
   </Card>
 </CardGrid>
+<!-- Linked-issue verification marker: #289. -->


### PR DESCRIPTION
Closes #289\n\nAdds one inert documentation marker to verify the canonical linked-issue PR check.