### PR TITLE
docs: use valid MDX comment syntax

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -30,4 +30,5 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     Fully typed configuration with IntelliSense support for a great developer experience.
   </Card>
 </CardGrid>
-<!-- Linked-issue verification marker: #289. -->
+
+{/*Linked-issue verification marker: #289.*/}


### PR DESCRIPTION
Replace the invalid HTML comment in `docs/index.mdx` with an MDX expression comment so the immutable documentation builder can parse and publish the page.

Closes #299